### PR TITLE
Fixed DrawName to use color of entity setting and added global override.

### DIFF
--- a/cheat-library/src/user/cheat/esp/ESP.cpp
+++ b/cheat-library/src/user/cheat/esp/ESP.cpp
@@ -24,6 +24,7 @@ namespace cheat::feature
 
         NF(m_FontSize, "Font size", "ESP", 12.0f),
         NF(m_FontColor, "Font color", "ESP", ImColor(255, 255, 255)),
+		NF(m_ApplyGlobalFontColor, "Apply global font colors", "ESP", false),
 
         NF(m_MinSize, "Min in world size", "ESP", 0.5f),
 		NF(m_Range, "Range", "ESP", 100.0f)
@@ -58,6 +59,8 @@ namespace cheat::feature
         ImGui::Spacing();
         ConfigWidget(m_FontSize, 0.05f, 1.0f, 100.0f, "Font size of name or distance.");
         ConfigWidget(m_FontColor, "Color of name or distance text font.");
+		ConfigWidget(m_ApplyGlobalFontColor, "Override all color settings with above font color setting.\n"
+			"Turn off to revert to custom settings.");
 
         ConfigWidget(m_MinSize, 0.05f, 0.1f, 200.0f, "Minimal object size in world.\n"
             "Some entities have not bounds or bounds is too small, this parameter help set minimal size of this type object.");
@@ -181,7 +184,10 @@ namespace cheat::feature
 					if (!entry.m_Enabled || !m_FilterExecutor.ApplyFilter(entity, filter))
 						continue;
 
-					esp::render::DrawEntity(entry.m_Name, entity, entry.m_Color);
+					ImColor entityColor = entry.m_Color;
+					if (m_ApplyGlobalFontColor)
+						entityColor = esp.m_FontColor;
+					esp::render::DrawEntity(entry.m_Name, entity, entityColor);
 					break;
 				}
 			}

--- a/cheat-library/src/user/cheat/esp/ESP.cpp
+++ b/cheat-library/src/user/cheat/esp/ESP.cpp
@@ -185,8 +185,6 @@ namespace cheat::feature
 						continue;
 
 					ImColor entityColor = entry.m_Color;
-					if (m_ApplyGlobalFontColor)
-						entityColor = esp.m_FontColor;
 					esp::render::DrawEntity(entry.m_Name, entity, entityColor);
 					break;
 				}

--- a/cheat-library/src/user/cheat/esp/ESP.h
+++ b/cheat-library/src/user/cheat/esp/ESP.h
@@ -30,6 +30,7 @@ namespace cheat::feature
 
 		config::field::BaseField<float> m_FontSize;
 		config::field::ColorField m_FontColor;
+		config::field::BaseField<bool> m_ApplyGlobalFontColor;
 
 		config::field::BaseField<float> m_MinSize;
 		config::field::BaseField<float> m_Range;

--- a/cheat-library/src/user/cheat/esp/ESPRender.cpp
+++ b/cheat-library/src/user/cheat/esp/ESPRender.cpp
@@ -442,7 +442,12 @@ namespace cheat::feature::esp::render
 			DrawLine(entity, color);
 
 		if (esp.m_DrawName)
-			DrawName(rect, entity, name, color);
+		{
+			ImColor nameColor = color;
+			if (esp.m_ApplyGlobalFontColor)
+				nameColor = esp.m_FontColor;
+			DrawName(rect, entity, name, nameColor);
+		}
 
 		return HasCenter(rect);
 	}

--- a/cheat-library/src/user/cheat/esp/ESPRender.cpp
+++ b/cheat-library/src/user/cheat/esp/ESPRender.cpp
@@ -392,7 +392,7 @@ namespace cheat::feature::esp::render
 		draw->AddLine(s_AvatarPosition, *screenPos, color);
 	}
 
-	static void DrawName(const Rect& boxRect, game::Entity* entity, const std::string& name)
+	static void DrawName(const Rect& boxRect, game::Entity* entity, const std::string& name, const ImColor& color)
 	{
 		auto& esp = ESP::GetInstance();
 		auto& manager = game::EntityManager::instance();
@@ -417,7 +417,7 @@ namespace cheat::feature::esp::render
 			text = name;
 
 		auto draw = ImGui::GetBackgroundDrawList();
-		draw->AddText(NULL, esp.m_FontSize, namePosition, esp.m_FontColor.value(), text.c_str());
+		draw->AddText(NULL, esp.m_FontSize, namePosition, color, text.c_str());
 	}
 
 	bool DrawEntity(const std::string& name, game::Entity* entity, const ImColor& color)
@@ -442,7 +442,7 @@ namespace cheat::feature::esp::render
 			DrawLine(entity, color);
 
 		if (esp.m_DrawName)
-			DrawName(rect, entity, name);
+			DrawName(rect, entity, name, color);
 
 		return HasCenter(rect);
 	}


### PR DESCRIPTION
Should fix #100. Also added an option to use a global override for reasons stated in #100, adding here for visibility:

> I'm thinking not to remove the `esp.m_FontColor` completely. It has its uses--for example, if you have settings of blue/pink but suddenly find yourself in Watatsumi, ESP will look like crap because of all the blue/pink. In those cases, having a global color to override all colors like a toggle should be ideal so you can still retain original settings but can have brief moments where you can change to a different color.