### PR TITLE
Fixed ESP text pos when not using rectangles/boxes + typo fixes to ESP.

### DIFF
--- a/cheat-library/src/user/cheat/esp/ESP.cpp
+++ b/cheat-library/src/user/cheat/esp/ESP.cpp
@@ -249,7 +249,7 @@ namespace cheat::feature
 		ADD_FILTER_FIELD(featured, Anemoculus);
 		ADD_FILTER_FIELD(featured, CrimsonAgate);
 		ADD_FILTER_FIELD(featured, Electroculus);
-		ADD_FILTER_FIELD(featured, Electrogranur);
+		ADD_FILTER_FIELD(featured, Electrogranum);
 		ADD_FILTER_FIELD(featured, Geoculus);
 		ADD_FILTER_FIELD(featured, ShrineOfDepth);
 		ADD_FILTER_FIELD(featured, TimeTrial);
@@ -277,7 +277,7 @@ namespace cheat::feature
 		ADD_FILTER_FIELD(mineral, ArchaicStone);
 		ADD_FILTER_FIELD(mineral, CorLapis);
 		ADD_FILTER_FIELD(mineral, CrystalChunk);
-		ADD_FILTER_FIELD(mineral, CrystallMarrow);
+		ADD_FILTER_FIELD(mineral, CrystalMarrow);
 		ADD_FILTER_FIELD(mineral, ElectroCrystal);
 		ADD_FILTER_FIELD(mineral, IronChunk);
 		ADD_FILTER_FIELD(mineral, NoctilucousJade);
@@ -290,7 +290,7 @@ namespace cheat::feature
 		ADD_FILTER_FIELD(monster, FatuiMirrorMaiden);
 		ADD_FILTER_FIELD(monster, FatuiSkirmisher);
 		ADD_FILTER_FIELD(monster, Geovishap);
-		ADD_FILTER_FIELD(monster, GeovishapHatchiling);
+		ADD_FILTER_FIELD(monster, GeovishapHatchling);
 		ADD_FILTER_FIELD(monster, Hilichurl);
 		ADD_FILTER_FIELD(monster, Mitachurl);
 		ADD_FILTER_FIELD(monster, Nobushi);
@@ -302,7 +302,7 @@ namespace cheat::feature
 		ADD_FILTER_FIELD(monster, Specter);
 		ADD_FILTER_FIELD(monster, TreasureHoarder);
 		ADD_FILTER_FIELD(monster, UnusualHilichurl);
-		ADD_FILTER_FIELD(monster, Whooperflower);
+		ADD_FILTER_FIELD(monster, Whopperflower);
 		ADD_FILTER_FIELD(monster, WolvesOfTheRift);
 
 		ADD_FILTER_FIELD(plant, AmakumoFruit);
@@ -356,7 +356,7 @@ namespace cheat::feature
 		ADD_FILTER_FIELD(puzzle, Geogranum);
 		ADD_FILTER_FIELD(puzzle, LargeRockPile);
 		ADD_FILTER_FIELD(puzzle, LightUpTilePuzzle);
-		ADD_FILTER_FIELD(puzzle, LightingStrikeProbe);
+		ADD_FILTER_FIELD(puzzle, LightningStrikeProbe);
 		ADD_FILTER_FIELD(puzzle, MistBubble);
 		ADD_FILTER_FIELD(puzzle, PirateHelm);
 		ADD_FILTER_FIELD(puzzle, PressurePlate);

--- a/cheat-library/src/user/cheat/esp/ESPRender.cpp
+++ b/cheat-library/src/user/cheat/esp/ESPRender.cpp
@@ -396,6 +396,14 @@ namespace cheat::feature::esp::render
 	{
 		auto& esp = ESP::GetInstance();
 		auto& manager = game::EntityManager::instance();
+		
+		std::string text;
+		if (esp.m_DrawName && esp.m_DrawDistance)
+			text = fmt::format("{} | {:.1f}m", name, manager.avatar()->distance(entity));
+		else if (esp.m_DrawDistance)
+			text = fmt::format("{:.1f}m", manager.avatar()->distance(entity));
+		else
+			text = name;
 
 		ImVec2 namePosition;
 		if (!boxRect.empty())
@@ -406,15 +414,14 @@ namespace cheat::feature::esp::render
 			if (!screenPos)
 				return;
 			namePosition = *screenPos;
+
+			// Might need to be aware of performance hit but there shouldn't be any.
+			ImGuiContext& g = *GImGui;
+			ImFont* font = g.Font;
+			auto textSize = font->CalcTextSizeA(esp.m_FontSize, FLT_MAX, FLT_MAX, text.c_str());
+			namePosition.x -= (textSize.x / 2.0);
+			namePosition.y -= esp.m_FontSize;
 		}
-		
-		std::string text;
-		if (esp.m_DrawName && esp.m_DrawDistance)
-			text = fmt::format("{} | {:.1f}m", name, manager.avatar()->distance(entity));
-		else if (esp.m_DrawDistance)
-			text = fmt::format("{:.1f}m", manager.avatar()->distance(entity));
-		else
-			text = name;
 
 		auto draw = ImGui::GetBackgroundDrawList();
 		draw->AddText(NULL, esp.m_FontSize, namePosition, color, text.c_str());

--- a/cheat-library/src/user/cheat/game/filters.cpp
+++ b/cheat-library/src/user/cheat/game/filters.cpp
@@ -32,7 +32,7 @@ namespace cheat::game::filters
 		SimpleFilter Anemoculus = { app::EntityType__Enum_1::GatherObject, "WindCrystalShell" };
 		SimpleFilter CrimsonAgate = { app::EntityType__Enum_1::GatherObject, "Prop_Essence" };
 		SimpleFilter Electroculus = { app::EntityType__Enum_1::GatherObject, "Prop_ElectricCrystal" };
-		SimpleFilter Electrogranur = { app::EntityType__Enum_1::Gadget, "ThunderSeedCreate" };
+		SimpleFilter Electrogranum = { app::EntityType__Enum_1::Gadget, "ThunderSeedCreate" };
 		SimpleFilter Geoculus = { app::EntityType__Enum_1::GatherObject, "RockCrystalShell" };
 		SimpleFilter Lumenspar = { app::EntityType__Enum_1::GatherObject, "CelestiaSplinter" };
 		SimpleFilter KeySigil = { app::EntityType__Enum_1::GatherObject, "RuneContent" };
@@ -71,7 +71,7 @@ namespace cheat::game::filters
 		SimpleFilter ArchaicStone = { app::EntityType__Enum_1::GatherObject, "AncientOre" };
 		SimpleFilter CorLapis = { app::EntityType__Enum_1::GatherObject, "_ElementRock" };
 		SimpleFilter CrystalChunk = { app::EntityType__Enum_1::GatherObject, "_OreCrystal" };
-		SimpleFilter CrystallMarrow = { app::EntityType__Enum_1::GatherObject, "_Crystalizedmarrow" };
+		SimpleFilter CrystalMarrow = { app::EntityType__Enum_1::GatherObject, "_Crystalizedmarrow" };
 		SimpleFilter ElectroCrystal = { app::EntityType__Enum_1::GatherObject, "_OreElectricRock" };
 		SimpleFilter IronChunk = { app::EntityType__Enum_1::GatherObject, "_OreStone" };
 		SimpleFilter NoctilucousJade = { app::EntityType__Enum_1::GatherObject, "_OreNightBerth" };
@@ -87,7 +87,7 @@ namespace cheat::game::filters
 		SimpleFilter FatuiMirrorMaiden = { app::EntityType__Enum_1::Monster, "_Fatuus_Maiden" };
 		SimpleFilter FatuiSkirmisher = { app::EntityType__Enum_1::Monster, "_Skirmisher" };
 		SimpleFilter Geovishap = { app::EntityType__Enum_1::Monster, "_Drake" };
-		SimpleFilter GeovishapHatchiling = { app::EntityType__Enum_1::Monster, "_Wyrm" };
+		SimpleFilter GeovishapHatchling = { app::EntityType__Enum_1::Monster, "_Wyrm" };
 		SimpleFilter Hilichurl = { app::EntityType__Enum_1::Monster, "_Hili" };
 		SimpleFilter Mitachurl = { app::EntityType__Enum_1::Monster, "_Brute" };
 		SimpleFilter Nobushi = { app::EntityType__Enum_1::Monster, "_Samurai" };
@@ -99,7 +99,7 @@ namespace cheat::game::filters
 		SimpleFilter Specter = { app::EntityType__Enum_1::Monster, "_Sylph" };
 		SimpleFilter TreasureHoarder = { app::EntityType__Enum_1::Monster, "_Thoarder" };
 		SimpleFilter UnusualHilichurl = { app::EntityType__Enum_1::Monster, "_Hili_Wei" };
-		SimpleFilter Whooperflower = { app::EntityType__Enum_1::Monster, "_Mimik" };
+		SimpleFilter Whopperflower = { app::EntityType__Enum_1::Monster, "_Mimik" };
 		SimpleFilter WolvesOfTheRift = { app::EntityType__Enum_1::Monster, "_Hound_Kanis" };
 	}
 
@@ -159,7 +159,7 @@ namespace cheat::game::filters
 		SimpleFilter Geogranum = { app::EntityType__Enum_1::Field, "_Rockstraight_" };
 		SimpleFilter LargeRockPile = { app::EntityType__Enum_1::Gadget, "_StonePile_" };
 		SimpleFilter LightUpTilePuzzle = { app::EntityType__Enum_1::Field, "_TwinStoryFloor" };
-		SimpleFilter LightingStrikeProbe = { app::EntityType__Enum_1::Gadget, "_MagneticGear" };
+		SimpleFilter LightningStrikeProbe = { app::EntityType__Enum_1::Gadget, "_MagneticGear" };
 		SimpleFilter MistBubble = { app::EntityType__Enum_1::Platform, "_Suspiciousbubbles" };
 		SimpleFilter PirateHelm = { app::EntityType__Enum_1::Field, "_PirateHelm" };
 		SimpleFilter PressurePlate = { app::EntityType__Enum_1::Field, "Gear_Gravity" };

--- a/cheat-library/src/user/cheat/game/filters.h
+++ b/cheat-library/src/user/cheat/game/filters.h
@@ -34,7 +34,7 @@ namespace cheat::game::filters
 		extern SimpleFilter Anemoculus;
 		extern SimpleFilter CrimsonAgate;
 		extern SimpleFilter Electroculus;
-		extern SimpleFilter Electrogranur;
+		extern SimpleFilter Electrogranum;
 		extern SimpleFilter Geoculus;
 		extern SimpleFilter Lumenspar;
 		extern SimpleFilter KeySigil;
@@ -73,7 +73,7 @@ namespace cheat::game::filters
 		extern SimpleFilter ArchaicStone;
 		extern SimpleFilter CorLapis;
 		extern SimpleFilter CrystalChunk;
-		extern SimpleFilter CrystallMarrow;
+		extern SimpleFilter CrystalMarrow;
 		extern SimpleFilter ElectroCrystal;
 		extern SimpleFilter IronChunk;
 		extern SimpleFilter NoctilucousJade;
@@ -89,7 +89,7 @@ namespace cheat::game::filters
 		extern SimpleFilter FatuiMirrorMaiden;
 		extern SimpleFilter FatuiSkirmisher;
 		extern SimpleFilter Geovishap;
-		extern SimpleFilter GeovishapHatchiling;
+		extern SimpleFilter GeovishapHatchling;
 		extern SimpleFilter Hilichurl;
 		extern SimpleFilter Mitachurl;
 		extern SimpleFilter Nobushi;
@@ -101,7 +101,7 @@ namespace cheat::game::filters
 		extern SimpleFilter Specter;
 		extern SimpleFilter TreasureHoarder;
 		extern SimpleFilter UnusualHilichurl;
-		extern SimpleFilter Whooperflower;
+		extern SimpleFilter Whopperflower;
 		extern SimpleFilter WolvesOfTheRift;
 	}
 
@@ -161,7 +161,7 @@ namespace cheat::game::filters
 		extern SimpleFilter Geogranum;
 		extern SimpleFilter LargeRockPile;
 		extern SimpleFilter LightUpTilePuzzle;
-		extern SimpleFilter LightingStrikeProbe;
+		extern SimpleFilter LightningStrikeProbe;
 		extern SimpleFilter MistBubble;
 		extern SimpleFilter PirateHelm;
 		extern SimpleFilter PressurePlate;


### PR DESCRIPTION
Does not affect Rectangle/Box mode.

![image](https://user-images.githubusercontent.com/6817524/163701729-d6552995-a56d-4bf1-931e-8ea56404bba1.png)

Without Rectangle/Box, should align perfectly above line and actual entity screen center.

![GenshinImpact_LzCID10Mck](https://user-images.githubusercontent.com/6817524/163701701-9bb8f9be-6594-4cbf-81e8-16d6e2569e34.png)

Also pixel perfect even if font is much higher.

![GenshinImpact_6IMZokld5n](https://user-images.githubusercontent.com/6817524/163701711-ad02a5b4-f9ea-406f-a5aa-29a480ec2ede.png)

Should solve #104.