### PR TITLE
Fixed  some entity names

### DIFF
--- a/cheat-library/src/user/cheat/esp/ESP.cpp
+++ b/cheat-library/src/user/cheat/esp/ESP.cpp
@@ -354,6 +354,7 @@ namespace cheat::feature
 		ADD_FILTER_FIELD(puzzle, ElementalMonument);
 		ADD_FILTER_FIELD(puzzle, FloatingAnemoSlime);
 		ADD_FILTER_FIELD(puzzle, Geogranum);
+		ADD_FILTER_FIELD(puzzle, GeoPuzzle)
 		ADD_FILTER_FIELD(puzzle, LargeRockPile);
 		ADD_FILTER_FIELD(puzzle, LightUpTilePuzzle);
 		ADD_FILTER_FIELD(puzzle, LightningStrikeProbe);

--- a/cheat-library/src/user/cheat/esp/ESP.cpp
+++ b/cheat-library/src/user/cheat/esp/ESP.cpp
@@ -354,7 +354,7 @@ namespace cheat::feature
 		ADD_FILTER_FIELD(puzzle, ElementalMonument);
 		ADD_FILTER_FIELD(puzzle, FloatingAnemoSlime);
 		ADD_FILTER_FIELD(puzzle, Geogranum);
-		ADD_FILTER_FIELD(puzzle, GeoPuzzle)
+		ADD_FILTER_FIELD(puzzle, GeoPuzzle);
 		ADD_FILTER_FIELD(puzzle, LargeRockPile);
 		ADD_FILTER_FIELD(puzzle, LightUpTilePuzzle);
 		ADD_FILTER_FIELD(puzzle, LightningStrikeProbe);

--- a/cheat-library/src/user/cheat/game/filters.cpp
+++ b/cheat-library/src/user/cheat/game/filters.cpp
@@ -156,8 +156,9 @@ namespace cheat::game::filters
 		SimpleFilter ElectroSeelie = { app::EntityType__Enum_1::Platform, "_ElectricSeelie" };
 		SimpleFilter ElementalMonument = { app::EntityType__Enum_1::Gear, "_ElemTablet" };
 		SimpleFilter FloatingAnemoSlime = { app::EntityType__Enum_1::Platform, "_WindSlime" };
-		SimpleFilter Geogranum = { app::EntityType__Enum_1::Field, "_Rockstraight_" };
-		SimpleFilter LargeRockPile = { app::EntityType__Enum_1::Gadget, "_StonePile_" };
+		SimpleFilter Geogranum = { app::EntityType__Enum_1::Gadget, "_Property_Prop_RockFragment" };
+		SimpleFilter GeoPuzzle = { app::EntityType__Enum_1::Field, "_Rockstraight_" };
+		SimpleFilter LargeRockPile = { app::EntityType__Enum_1::Gadget, "_StonePile_02" };
 		SimpleFilter LightUpTilePuzzle = { app::EntityType__Enum_1::Field, "_TwinStoryFloor" };
 		SimpleFilter LightningStrikeProbe = { app::EntityType__Enum_1::Gadget, "_MagneticGear" };
 		SimpleFilter MistBubble = { app::EntityType__Enum_1::Platform, "_Suspiciousbubbles" };
@@ -165,7 +166,7 @@ namespace cheat::game::filters
 		SimpleFilter PressurePlate = { app::EntityType__Enum_1::Field, "Gear_Gravity" };
 		SimpleFilter SeelieLamp = { app::EntityType__Enum_1::Field, "Gear_SeeliaLamp" };
 		SimpleFilter Seelie = { app::EntityType__Enum_1::Platform, "Gear_Seelie" };
-		SimpleFilter SmallRockPile = { app::EntityType__Enum_1::Gadget, "_Property_Prop_RockFragment" };
+		SimpleFilter SmallRockPile = { app::EntityType__Enum_1::Gadget, "_StonePile_01" };
 		SimpleFilter StormBarrier = { app::EntityType__Enum_1::Field, "_WindField_PushField" };
 		SimpleFilter SwordHilt = { app::EntityType__Enum_1::Field, "_WastedSword_" };
 		SimpleFilter TorchPuzzle = { app::EntityType__Enum_1::Gadget, "_ImmortalFire" };

--- a/cheat-library/src/user/cheat/game/filters.h
+++ b/cheat-library/src/user/cheat/game/filters.h
@@ -159,6 +159,7 @@ namespace cheat::game::filters
 		extern SimpleFilter ElementalMonument;
 		extern SimpleFilter FloatingAnemoSlime;
 		extern SimpleFilter Geogranum;
+		extern SimpleFilter GeoPuzzle;
 		extern SimpleFilter LargeRockPile;
 		extern SimpleFilter LightUpTilePuzzle;
 		extern SimpleFilter LightningStrikeProbe;


### PR DESCRIPTION
Fixed confusion between geogranums, piles of rocks, and added Geogranum Puzzle (Currently Geopuzzle, but can be renamed because ' GeogranumPuzzle ' was giving me an unresolved symbol error

Examples of Non-fixed
![smallrockpile](https://user-images.githubusercontent.com/84017229/163719447-3ce9cbb7-532b-4ef5-84f3-7fe7237e2bb3.png)
![geogranum puzzle](https://user-images.githubusercontent.com/84017229/163719450-fa6f0866-e192-459a-a18f-50b35f4810ea.png)
![geogranum](https://user-images.githubusercontent.com/84017229/163719452-8a1a0e31-3637-498b-b684-d35627314ebf.png)

Fixed:
![fixed_large_rock](https://user-images.githubusercontent.com/84017229/163719843-46d01ba2-c358-4335-a063-4f7a9df02424.png)
![fixed](https://user-images.githubusercontent.com/84017229/163719845-eba72251-5608-4f3c-bd37-b3f4af6a541d.png)

