### PR TITLE
Refactoring and lots of small changes to Entity Manager visuals.

### DIFF
--- a/cheat-library/src/user/cheat/misc/Debug.cpp
+++ b/cheat-library/src/user/cheat/misc/Debug.cpp
@@ -365,7 +365,6 @@ namespace cheat::feature
 
     std::vector<game::Entity*> SortEntities(std::vector<game::Entity*> entities, Debug::EntitySortCondition condition)
     {
-        LOG_DEBUG("Condition Sort %d", condition);
         switch (condition) {
         case Debug::EntitySortCondition::RuntimeID: {
                 std::sort(entities.begin(),
@@ -508,7 +507,9 @@ namespace cheat::feature
             ImGui::BeginDisabled();
             
         ImGui::SameLine();
+        ImGui::PushItemWidth(200.0);
         ImGui::SliderFloat("Radius", &radius, 0.0f, 100.0f);
+        ImGui::PopItemWidth();
         if (!useRadius)
             ImGui::EndDisabled();
 

--- a/cheat-library/src/user/cheat/misc/Debug.cpp
+++ b/cheat-library/src/user/cheat/misc/Debug.cpp
@@ -404,13 +404,13 @@ namespace cheat::feature
     void DrawEntitiesTable(std::vector<game::Entity*> entities)
     {
         auto& manager = game::EntityManager::instance();
-        auto clipSize = min(entities.size(), 15); // Number of rows in table as initial view. Past this is scrollbar territory.
+        auto clipSize = min(entities.size(), 15) + 1; // Number of rows in table as initial view. Past this is scrollbar territory.
 
         static ImGuiTableFlags flags =
             ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable | ImGuiTableFlags_Hideable // | ImGuiTableFlags_Sortable | ImGuiTableFlags_SortMulti
             | ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV | ImGuiTableFlags_NoBordersInBody
             | ImGuiTableFlags_ScrollY;
-        if (ImGui::BeginTable("EntityTable", 8, flags, ImVec2(0.0f, ImGui::GetTextLineHeightWithSpacing() * 15), 0.0f))
+        if (ImGui::BeginTable("EntityTable", 8, flags, ImVec2(0.0f, ImGui::GetTextLineHeightWithSpacing() * clipSize), 0.0f))
         {
             ImGui::TableSetupColumn("Commands", ImGuiTableColumnFlags_NoSort | ImGuiTableColumnFlags_WidthFixed, 0.0, 0);
             ImGui::TableSetupColumn("ID", ImGuiTableColumnFlags_WidthFixed, 0.0f, 1);

--- a/cheat-library/src/user/cheat/misc/Debug.h
+++ b/cheat-library/src/user/cheat/misc/Debug.h
@@ -10,15 +10,24 @@ namespace cheat::feature
 
 		static Debug& GetInstance();
 
+		enum class TeleportCondition {
+			Closest,
+			Farthest
+		};
+
+		enum class EntitySortCondition {
+			RuntimeID = 0,
+			Name,
+			Distance
+		};
+
 		const FeatureGUIInfo& GetGUIInfo() const override;
 		void DrawMain() override;
 
 		virtual bool NeedInfoDraw() const override;
 		void DrawInfo() override;
 	
-
 		void DrawExternal() override;
-
 	private:
 		Debug();
 	};


### PR DESCRIPTION
- Lots of refactoring in the code to enforce DRY/best practices, etc.
- Added sorting by RuntimeID, Name, or Distance.
- Added an option to view entities as one table or grouped by type.
- Moved around some logic stuff (like `Show Empty Types` appearing only if `Group by Type` is enabled).
- Moved buttons to first column.
- Added `entity->absolutePosition()` details.
- Added `Copy All Details` group action to easily copy all row details.
- Cosmetic changes to some parts (e.g. length of slider, typo, capitalization, etc.).
- Added small combat data on valid entities (when hovering on second/entity column).
  - Will be improved.

![image](https://user-images.githubusercontent.com/6817524/166150314-b7bacc71-57ca-4c99-9897-042ed2713c32.png)

![image](https://user-images.githubusercontent.com/6817524/166150650-a1d41b87-a7ae-43b9-94cc-4a4569065fd9.png)

![image](https://user-images.githubusercontent.com/6817524/166150744-994f0837-a2f9-48e7-898a-d8f36a58a212.png)
