### PR TITLE
Fixed UpdateFilters and Multithit.

### DIFF
--- a/cheat-library/src/user/cheat/game/filters.cpp
+++ b/cheat-library/src/user/cheat/game/filters.cpp
@@ -427,6 +427,7 @@ namespace cheat::game::filters
 				"Ningyo", "Regisvine", "Hypostasis", "Planelurker", "Nithhoggr"
 			}
 		};
+		SimpleFilter OrganicTargets = Monsters + Animals; // Solael: Please don't mess around with this filter.
 		//m0nkrel: We can choose the entities we need ourselves so as not to magnetize cats, dogs, etc.
 		//AdvancedFilter Animals = { std::vector<app::EntityType__Enum_1> {app::EntityType__Enum_1::EnvAnimal, app::EntityType__Enum_1::Monster }, std::vector<std::string> {"Crane","Tit", "Boar" , "Squirrel", "Fox", "Pigeon", "Wigeon", "Falcon" ,"Marten" } };
 	}

--- a/cheat-library/src/user/cheat/game/filters.h
+++ b/cheat-library/src/user/cheat/game/filters.h
@@ -268,5 +268,6 @@ namespace cheat::game::filters
 		extern SimpleFilter MonsterShielded;
 		extern SimpleFilter MonsterEquips;
         extern BlacklistFilter Living;
+		extern SimpleFilter OrganicTargets;
 	}
 }

--- a/cheat-library/src/user/cheat/player/RapidFire.cpp
+++ b/cheat-library/src/user/cheat/player/RapidFire.cpp
@@ -195,7 +195,7 @@ namespace cheat::feature
 
 		auto& manager = game::EntityManager::instance();
 		auto originalTarget = manager.entity(targetID);
-		if (!game::filters::combined::Living.IsValid(originalTarget))
+		if (!game::filters::combined::OrganicTargets.IsValid(originalTarget))
 			return callOrigin(LCBaseCombat_DoHitEntity_Hook, __this, targetID, attackResult, ignoreCheckCanBeHitInMP, method);
 
 		std::vector<cheat::game::Entity*> validEntities;

--- a/cheat-library/src/user/cheat/world/MobVacuum.cpp
+++ b/cheat-library/src/user/cheat/world/MobVacuum.cpp
@@ -52,7 +52,7 @@ namespace cheat::feature
     	BeginGroupPanel("Animals", ImVec2(-1, 0));
         {
             filtersChanged |= ConfigWidget(f_IncludeAnimals, "Include animals in vacuum.");
-            filtersChanged |= ConfigWidget(f_AnimalDrop, "Animals you need to defeat before collect."); ImGui::SameLine();
+            filtersChanged |= ConfigWidget(f_AnimalDrop, "Animals you need to kill before collecting."); ImGui::SameLine();
             filtersChanged |= ConfigWidget(f_AnimalPickUp, "Animals you can immediately collect."); ImGui::SameLine();
             filtersChanged |= ConfigWidget(f_AnimalNPC, "Animals without mechanics.");
         }
@@ -63,14 +63,14 @@ namespace cheat::feature
 
     	ConfigWidget("Instant Vacuum", f_Instantly, "Vacuum entities instantly.");
         ConfigWidget("Only Hostile/Aggro", f_OnlyTarget, "If enabled, vacuum will only affect monsters targeting you. Will not affect animals.");
-        ConfigWidget("Speed", f_Speed, 0.1f, 1.0f, 15.0f, "If 'Instant Vacuum' not checked, mob will be vacuumed at the specified speed.");
+        ConfigWidget("Speed", f_Speed, 0.1f, 1.0f, 15.0f, "If 'Instant Vacuum' is not checked, mob will be vacuumed at the specified speed.");
         ConfigWidget("Radius (m)", f_Radius, 0.1f, 5.0f, 150.0f, "Radius of vacuum.");
         ConfigWidget("Distance (m)", f_Distance, 0.1f, 0.5f, 10.0f, "Distance between the player and the monster.");
     }
 
     bool MobVacuum::NeedStatusDraw() const
-{
-        return f_Enabled.value();
+    {
+        return f_Enabled;
     }
 
     void MobVacuum::DrawStatus() 
@@ -148,13 +148,14 @@ namespace cheat::feature
     {
         static auto positions = new std::map<uint32_t, app::Vector3>();
 
-        if (!f_Enabled.value())
+        if (!f_Enabled)
             return;
 
         app::Vector3 targetPos = CalcMobVacTargetPos();
         if (IsVectorZero(targetPos))
             return;
 
+        UpdateFilters();
         if (!f_IncludeMonsters && !f_IncludeAnimals)
             return;
 


### PR DESCRIPTION
- Fixes issue touched on in #270 about `UpdateFilters` not firing. It's now called inside `GameUpdate` to ensure it recalcs the filter every time. Doesn't seem to have performance hit.
- Fixes #266. BlacklistFilter blacklisted some bosses from being affected. Created a new filter for organic targets to be used for Multihit/RapidFire.

![GenshinImpact_DvXIPAZaBR](https://user-images.githubusercontent.com/6817524/166234111-529eff0e-7d0f-478e-b716-f2f4e9fb6834.png)
