### PR TITLE
Add Fast Exit

### DIFF
--- a/cheat-base/src/cheat-base/cheat/CheatManagerBase.cpp
+++ b/cheat-base/src/cheat-base/cheat/CheatManagerBase.cpp
@@ -401,6 +401,17 @@ namespace cheat
 		ImGui::RenderNotifications();
 	}
 
+	void CheatManagerBase::FastExit()
+	{
+		auto& settings = feature::Settings::GetInstance();
+		//if (!settings.f_FastExitEnable)
+		//	return;
+
+		if (!settings.f_HotkeyExit.value().IsPressed())
+		{
+			ExitProcess(0);
+		}
+	}
 	void CheatManagerBase::OnRender()
 	{
 		auto& settings = feature::Settings::GetInstance();
@@ -418,6 +429,9 @@ namespace cheat
 
 			ImGui::End();
 		}
+
+		if (settings.f_FastExitEnable)
+			FastExit();
 
 		if (settings.f_StatusShow)
 			DrawStatus();

--- a/cheat-base/src/cheat-base/cheat/CheatManagerBase.cpp
+++ b/cheat-base/src/cheat-base/cheat/CheatManagerBase.cpp
@@ -401,17 +401,7 @@ namespace cheat
 		ImGui::RenderNotifications();
 	}
 
-	void CheatManagerBase::FastExit()
-	{
-		auto& settings = feature::Settings::GetInstance();
-		//if (!settings.f_FastExitEnable)
-		//	return;
-
-		if (!settings.f_HotkeyExit.value().IsPressed())
-		{
-			ExitProcess(0);
-		}
-	}
+	
 	void CheatManagerBase::OnRender()
 	{
 		auto& settings = feature::Settings::GetInstance();
@@ -429,9 +419,6 @@ namespace cheat
 
 			ImGui::End();
 		}
-
-		if (settings.f_FastExitEnable)
-			FastExit();
 
 		if (settings.f_StatusShow)
 			DrawStatus();

--- a/cheat-base/src/cheat-base/cheat/CheatManagerBase.h
+++ b/cheat-base/src/cheat-base/cheat/CheatManagerBase.h
@@ -72,8 +72,6 @@ namespace cheat
 		virtual void DrawInfo();
 		void DrawFps();
 		static void DrawNotifications();
-		void FastExit();
-
 		void PushFeature(Feature* feature);
 		void CheckToggles(short key) const;
 

--- a/cheat-base/src/cheat-base/cheat/CheatManagerBase.h
+++ b/cheat-base/src/cheat-base/cheat/CheatManagerBase.h
@@ -72,6 +72,7 @@ namespace cheat
 		virtual void DrawInfo();
 		void DrawFps();
 		static void DrawNotifications();
+		void FastExit();
 
 		void PushFeature(Feature* feature);
 		void CheckToggles(short key) const;

--- a/cheat-base/src/cheat-base/cheat/misc/Settings.cpp
+++ b/cheat-base/src/cheat-base/cheat/misc/Settings.cpp
@@ -23,7 +23,10 @@ namespace cheat::feature
 		NF(f_NotificationsDelay, "Notifications Delay", "General::Notify", 500),
   
 		NF(f_FileLogging,    "File Logging",    "General::Logging", false),
-		NF(f_ConsoleLogging, "Console Logging", "General::Logging", true)
+		NF(f_ConsoleLogging, "Console Logging", "General::Logging", true),
+
+		NF(f_FastExitEnable, "Fast Exit", "General::FastExit", false),
+		NF(f_HotkeyExit, "Hotkeys", "General::FastExit", Hotkey(VK_F12))
 		
     {
 		renderer::SetGlobalFontSize(f_FontSize);
@@ -96,6 +99,23 @@ namespace cheat::feature
 		{
 			ConfigWidget(f_NotificationsShow, "Notifications on the bottom-right corner of the window will be displayed.");
 			ConfigWidget(f_NotificationsDelay, 1,1,10000, "Delay in milliseconds between notifications.");
+		}
+		EndGroupPanel();
+
+		BeginGroupPanel("Fast Exit", ImVec2(-1, 0));
+		{
+			ConfigWidget("Enabled",
+				f_FastExitEnable,
+				"Enable Fast Exit.\n" 
+			);
+			if (!f_FastExitEnable)
+				ImGui::BeginDisabled();
+
+			ConfigWidget("Key", f_HotkeyExit, true,
+				"Key to exit the game.");
+
+			if (!f_FastExitEnable)
+				ImGui::EndDisabled();
 		}
 		EndGroupPanel();
 	}

--- a/cheat-base/src/cheat-base/cheat/misc/Settings.cpp
+++ b/cheat-base/src/cheat-base/cheat/misc/Settings.cpp
@@ -116,8 +116,21 @@ namespace cheat::feature
 
 			if (!f_FastExitEnable)
 				ImGui::EndDisabled();
+
+			FastExit();
 		}
 		EndGroupPanel();
+	}
+
+	void Settings::FastExit()
+	{
+		if (!f_FastExitEnable)
+			return;
+
+		if (f_HotkeyExit.value().IsPressed())
+		{
+			ExitProcess(0);
+		}
 	}
 
     Settings& Settings::GetInstance()

--- a/cheat-base/src/cheat-base/cheat/misc/Settings.h
+++ b/cheat-base/src/cheat-base/cheat/misc/Settings.h
@@ -27,6 +27,9 @@ namespace cheat::feature
 		config::Field<bool> f_ConsoleLogging;
 		config::Field<bool> f_FileLogging;
 
+		config::Field<bool> f_FastExitEnable;
+		config::Field<Hotkey> f_HotkeyExit;
+
 		static Settings& GetInstance();
 
 		const FeatureGUIInfo& GetGUIInfo() const override;

--- a/cheat-base/src/cheat-base/cheat/misc/Settings.h
+++ b/cheat-base/src/cheat-base/cheat/misc/Settings.h
@@ -34,6 +34,8 @@ namespace cheat::feature
 
 		const FeatureGUIInfo& GetGUIInfo() const override;
 		void DrawMain() override;
+		void FastExit();
+
 	
 	private:
 		Settings();


### PR DESCRIPTION
I usually close Genshin with a launcher that I made myself, so adding this feature might be useful.
but there is still a bug where if you click "clear" the game will close and if you want to change the hotkey it will also close.

so i need help to fix this