### PR TITLE
easier noclip

### DIFF
--- a/cheat-library/src/user/cheat/player/NoClip.cpp
+++ b/cheat-library/src/user/cheat/player/NoClip.cpp
@@ -142,10 +142,10 @@ namespace cheat::feature
 			dir = dir + relativeEntity->left();
 
 		if (Hotkey(VK_SPACE).IsPressed())
-			dir = dir + relativeEntity->up();
+			dir = dir + avatarEntity->up();
 		
 		if (Hotkey(ImGuiKey_ModShift).IsPressed())
-			dir = dir + relativeEntity->down();
+			dir = dir + avatarEntity->down();
 
 		app::Vector3 prevPos = avatarEntity->relativePosition();
 		if (IsVectorZero(prevPos))


### PR DESCRIPTION
When using noclip with camera as the relative entity, space doesn't actually go upward, instead, Up from where the camera is facing.

This changes that so up is always up and down is always down