### PR TITLE
Improved autoloot.

### DIFF
--- a/cheat-library/src/user/cheat/player/NoCD.cpp
+++ b/cheat-library/src/user/cheat/player/NoCD.cpp
@@ -39,7 +39,7 @@ namespace cheat::feature
     void NoCD::DrawMain()
     {
 
-		ConfigWidget(f_UtimateMaxEnergy,
+		ConfigWidget("Max Burst Energy", f_UtimateMaxEnergy,
 			"Removes energy requirement for elemental bursts.\n" \
 			"(Energy bubble may appear incomplete but still usable).");
 
@@ -85,8 +85,8 @@ namespace cheat::feature
 
     void NoCD::DrawStatus() 
     {
-		ImGui::Text("NoCD [%s%s%s%s%s%s%s]",
-			f_AbilityReduce ? "Reduce" : "",
+		ImGui::Text("Cooldown\n[%s%s%s%s%s]",
+			f_AbilityReduce ? fmt::format("Reduce {:.1f}", f_AbilityReduceValue.value()).c_str() : "",
 			f_AbilityReduce && (f_InstantBow || f_Sprint) ? "|" : "",
 			f_InstantBow ? "Bow" : "",
 			f_InstantBow && f_Sprint ? "|" : "",

--- a/cheat-library/src/user/cheat/player/RapidFire.cpp
+++ b/cheat-library/src/user/cheat/player/RapidFire.cpp
@@ -27,7 +27,7 @@ namespace cheat::feature
 
     const FeatureGUIInfo& RapidFire::GetGUIInfo() const
     {
-        static const FeatureGUIInfo info{ "Attack Multiplier", "Player", true };
+        static const FeatureGUIInfo info{ "Attack Effects", "Player", true };
         return info;
     }
 

--- a/cheat-library/src/user/cheat/teleport/ChestTeleport.cpp
+++ b/cheat-library/src/user/cheat/teleport/ChestTeleport.cpp
@@ -41,7 +41,7 @@ namespace cheat::feature
 		if (ImGui::TreeNode("Filters"))
 		{
 
-			ImGui::Text("Type filters");
+			ImGui::Text("Type Filters");
 
 			ConfigWidget(f_FilterChest, "Enable chest detection and filters.");
 			ConfigWidget(f_FilterInvestigates);

--- a/cheat-library/src/user/cheat/world/AutoFish.cpp
+++ b/cheat-library/src/user/cheat/world/AutoFish.cpp
@@ -34,12 +34,12 @@ namespace cheat::feature
     void AutoFish::DrawMain()
     {
         ConfigWidget("Enabled", f_Enabled, "Automatically catch fish.");
-        ConfigWidget(f_DelayBeforeCatch, 100, 500, 4000, "Fish will be catch after this delay.");
+        ConfigWidget("Delay (ms)", f_DelayBeforeCatch, 100, 500, 4000, "Fish will be caught after this delay (in ms).");
 
         ImGui::Spacing();
 
         ConfigWidget(f_AutoRecastRod, "If enabled, rod will recasted. Without visualization.");
-        ConfigWidget(f_DelayBeforeRecast, 10, 100, 4000);
+        ConfigWidget("Delay (ms)", f_DelayBeforeRecast, 10, 100, 4000, "Rod will be recast after this delay (in ms).");
     }
 
     bool AutoFish::NeedStatusDraw() const

--- a/cheat-library/src/user/cheat/world/AutoLoot.cpp
+++ b/cheat-library/src/user/cheat/world/AutoLoot.cpp
@@ -37,18 +37,18 @@ namespace cheat::feature
 
     void AutoLoot::DrawMain()
     {
-		ConfigWidget("Auto loot", f_AutoLoot, "Loots dropped items.\n" \
+		ConfigWidget("Auto-pickup Drops", f_AutoLoot, "Automatically picks up dropped items.\n" \
             "Note: Custom range and low delay times are high-risk features.\n" \
 			"Abuse will definitely merit a ban.");
-		ConfigWidget("Open Chest", f_OpenChest, "Auto Open Chest.\n" \
+		ConfigWidget("Auto-open Chest", f_OpenChest, "Automatically opens chests.\n" \
 			"Note: Custom range and low delay times are high-risk features.\n" \
 			"Abuse will definitely merit a ban.");
 
-		ConfigWidget("Delay Time (ms)", f_DelayTime, 1, 0, 1000, "Delay (in ms) beetwen looting items.\n" \
+		ConfigWidget("Delay Time (ms)", f_DelayTime, 1, 0, 1000, "Delay (in ms) between loot/open actions.\n" \
             "Values under 200ms are unsafe.");
 		ConfigWidget("Use Custom Pickup Range", f_UseCustomRange, "Enable custom pickup range.\n" \
-            "Using this feature is not recommended, as it is easily detected by the server.");
-		ConfigWidget("Range (m)", f_CustomRange, 0.1f, 0.5f, 60.0f, "Modifies pickup range to this value (in meters).");
+            "High values are not recommended, as it is easily detected by the server.");
+		ConfigWidget("Range (m)", f_CustomRange, 0.1f, 0.5f, 60.0f, "Modifies pickup/open range to this value (in meters).");
     }
 
     bool AutoLoot::NeedStatusDraw() const
@@ -60,7 +60,7 @@ namespace cheat::feature
     {
 		ImGui::Text("Auto Loot [%dms%s]",
 			f_DelayTime.value(),
-			f_UseCustomRange ? fmt::format("|{:.1f}m ", f_CustomRange.value()).c_str() : "");
+			f_UseCustomRange ? fmt::format("|{:.1f}m", f_CustomRange.value()).c_str() : "");
 
 		if (f_OpenChest)
 			ImGui::Text("Auto Open Chest");

--- a/cheat-library/src/user/cheat/world/AutoLoot.cpp
+++ b/cheat-library/src/user/cheat/world/AutoLoot.cpp
@@ -14,11 +14,16 @@ namespace cheat::feature
 	static bool LCSelectPickup_IsOutPosition_Hook(void* __this, app::BaseEntity* entity, MethodInfo* method);
 
     AutoLoot::AutoLoot() : Feature(),
-        NF(f_AutoLoot,       "Auto loot",               "AutoLoot", false),
-		NF(f_OpenChest,      "Open Chest",              "AutoLoot", false),
-        NF(f_DelayTime,      "Delay time (in ms)",      "AutoLoot", 150),
-        NF(f_UseCustomRange, "Use custom pickup range", "AutoLoot", false),
-        NF(f_CustomRange,    "Pickup Range",            "AutoLoot", 5.0f),
+        NF(f_AutoPickup,     "Auto-pickup drops",               "AutoLoot", false),
+		NF(f_AutoTreasure,   "Auto-open treasures",             "AutoLoot", false),
+		NF(f_UseCustomRange, "Use custom pickup range",         "AutoLoot", false),
+		NF(f_Chest,			 "Chests",							"AutoLoot", false),
+		NF(f_Leyline,		 "Leylines",						"AutoLoot", false),
+		NF(f_Investigate,	 "Search points",					"AutoLoot", false),
+		NF(f_QuestInteract,  "Quest interacts",					"AutoLoot", false),
+        NF(f_Others,		 "Other treasures",					"AutoLoot", false),
+		NF(f_DelayTime,		 "Delay time (in ms)",				"AutoLoot", 150),
+        NF(f_CustomRange,    "Pickup Range",                    "AutoLoot", 5.0f),
 		toBeLootedItems(), nextLootTime(0)
     {
 		// Auto loot
@@ -37,33 +42,77 @@ namespace cheat::feature
 
     void AutoLoot::DrawMain()
     {
-		ConfigWidget("Auto-pickup Drops", f_AutoLoot, "Automatically picks up dropped items.\n" \
-            "Note: Custom range and low delay times are high-risk features.\n" \
-			"Abuse will definitely merit a ban.");
-		ConfigWidget("Auto-open Chest", f_OpenChest, "Automatically opens chests.\n" \
-			"Note: Custom range and low delay times are high-risk features.\n" \
-			"Abuse will definitely merit a ban.");
+		if (ImGui::BeginTable("AutoLootDrawTable", 2, ImGuiTableFlags_NoBordersInBody))
+		{
+			ImGui::TableNextRow();
+			ImGui::TableSetColumnIndex(0);
 
-		ConfigWidget("Delay Time (ms)", f_DelayTime, 1, 0, 1000, "Delay (in ms) between loot/open actions.\n" \
-            "Values under 200ms are unsafe.");
-		ConfigWidget("Use Custom Pickup Range", f_UseCustomRange, "Enable custom pickup range.\n" \
-            "High values are not recommended, as it is easily detected by the server.");
-		ConfigWidget("Range (m)", f_CustomRange, 0.1f, 0.5f, 60.0f, "Modifies pickup/open range to this value (in meters).");
+			BeginGroupPanel("Auto-Pickup", ImVec2(-1, 0));
+			{
+				ConfigWidget("Enabled", f_AutoPickup, "Automatically picks up dropped items.\n" \
+					"Note: Using this with custom range and low delay times is extremely risky.\n" \
+					"Abuse will definitely merit a ban.\n\n" \
+					"If using with custom range, make sure this is turned on FIRST.");
+				ImGui::SameLine();
+				ImGui::TextColored(ImColor(255, 165, 0, 255), "Read the note!");
+			}
+			EndGroupPanel();
+
+			BeginGroupPanel("Custom Pickup Range", ImVec2(-1, 0));
+			{
+				ConfigWidget("Enabled", f_UseCustomRange, "Enable custom pickup range.\n" \
+					"High values are not recommended, as it is easily detected by the server.\n\n" \
+					"If using with auto-pickup/auto-treasure, turn this on LAST.");
+				ImGui::SameLine();
+				ImGui::TextColored(ImColor(255, 165, 0, 255), "Read the note!");
+				ImGui::SetNextItemWidth(100.0f);
+				ConfigWidget("Range (m)", f_CustomRange, 0.1f, 0.5f, 40.0f, "Modifies pickup/open range to this value (in meters).");
+			}
+			EndGroupPanel();
+
+			BeginGroupPanel("Looting Speed", ImVec2(-1, 0));
+			{
+				ImGui::SetNextItemWidth(100.0f);
+				ConfigWidget("Delay Time (ms)", f_DelayTime, 1, 0, 1000, "Delay (in ms) between loot/open actions.\n" \
+					"Values under 200ms are unsafe.\nNot used if no auto-functions are on.");
+			}
+			EndGroupPanel();
+
+			ImGui::TableSetColumnIndex(1);
+			BeginGroupPanel("Auto-Treasure", ImVec2(-1, 0));
+			{
+				ConfigWidget("Enabled", f_AutoTreasure, "Automatically opens chests and other treasures.\n" \
+					"Note: Using this with custom range and low delay times is extremely risky.\n" \
+					"Abuse will definitely merit a ban.\n\n" \
+					"If using with custom range, make sure this is turned on FIRST.");
+				ImGui::SameLine();
+				ImGui::TextColored(ImColor(255, 165, 0, 255), "Read the note!");
+				ConfigWidget("Chests", f_Chest, "Common, precious, luxurious, etc.");
+				ConfigWidget("Leyline", f_Leyline, "Mora/XP, overworld/Trounce bosses, etc.");
+				ConfigWidget("Search Points", f_Investigate, "Marked as Investigate/Search, etc.");
+				ConfigWidget("Quest Interacts", f_QuestInteract, "Valid quest interact points.");
+				ConfigWidget("Others", f_Others, "Book Pages, Spincrystals, etc.");
+			}
+			EndGroupPanel();
+			ImGui::EndTable();
+		}		
     }
 
     bool AutoLoot::NeedStatusDraw() const
 {
-        return f_AutoLoot;
+        return f_AutoPickup || f_AutoTreasure || f_UseCustomRange;
     }
 
     void AutoLoot::DrawStatus() 
     {
-		ImGui::Text("Auto Loot [%dms%s]",
-			f_DelayTime.value(),
-			f_UseCustomRange ? fmt::format("|{:.1f}m", f_CustomRange.value()).c_str() : "");
-
-		if (f_OpenChest)
-			ImGui::Text("Auto Open Chest");
+		ImGui::Text("Auto Loot\n[%s%s%s%s%s%s]",
+			f_AutoPickup ? "AP" : "",
+			f_AutoPickup && (f_AutoTreasure || f_UseCustomRange) ? "|" : "",
+			f_AutoTreasure ? "AT" : "",
+			f_AutoTreasure && f_UseCustomRange ? "|" : "",
+			f_UseCustomRange ? fmt::format("CR{:.1f}m", f_CustomRange.value()).c_str() : "",
+			f_AutoPickup || f_AutoTreasure ? fmt::format("|{}ms", f_DelayTime.value()).c_str() : ""
+		);
     }
 
     AutoLoot& AutoLoot::GetInstance()
@@ -74,7 +123,7 @@ namespace cheat::feature
 
 	bool AutoLoot::OnCreateButton(app::BaseEntity* entity)
 	{
-		if (!f_AutoLoot)
+		if (!f_AutoPickup)
 			return false;
 
 		auto itemModule = GET_SINGLETON(ItemModule);
@@ -103,7 +152,7 @@ namespace cheat::feature
 			return;
 
 		// RyujinZX#6666
-		if (f_OpenChest) 
+		if (f_AutoTreasure) 
 		{
 			auto& manager = game::EntityManager::instance();
 			for (auto& entity : manager.entities(game::filters::combined::Chests)) 
@@ -113,10 +162,31 @@ namespace cheat::feature
 					continue;
 
 				auto chest = reinterpret_cast<game::Chest*>(entity);
+				auto chestType = chest->itemType();
 
-				auto ChestState = chest->chestState();
-				if (ChestState != game::Chest::ChestState::None)
+				if (!f_Investigate && chestType == game::Chest::ItemType::Investigate)
 					continue;
+
+				if (!f_QuestInteract && chestType == game::Chest::ItemType::QuestInteract)
+					continue;
+
+				if (!f_Others && (
+					chestType == game::Chest::ItemType::BGM ||
+					chestType == game::Chest::ItemType::BookPage
+					))
+					continue;
+
+				if (!f_Leyline && chestType == game::Chest::ItemType::Flora)
+					continue;
+
+				if (chestType == game::Chest::ItemType::Chest)
+				{
+					if (!f_Chest)
+						continue;
+					auto ChestState = chest->chestState();
+					if (ChestState != game::Chest::ChestState::None)
+						continue;
+				}
 
 				uint32_t entityId = entity->runtimeID();
 				toBeLootedItems.push(entityId);
@@ -141,10 +211,10 @@ namespace cheat::feature
 
 	void AutoLoot::OnCheckIsInPosition(bool& result, app::BaseEntity* entity)
 	{
-		if (f_AutoLoot && f_UseCustomRange)
-		{
+		if (f_AutoPickup || f_UseCustomRange) {
+			float pickupRange = f_UseCustomRange ? f_CustomRange : 3.5f;
 			auto& manager = game::EntityManager::instance();
-			result = manager.avatar()->distance(entity) < f_CustomRange;
+			result = manager.avatar()->distance(entity) < pickupRange;
 		}
 	}
 

--- a/cheat-library/src/user/cheat/world/AutoLoot.h
+++ b/cheat-library/src/user/cheat/world/AutoLoot.h
@@ -9,12 +9,18 @@ namespace cheat::feature
 	class AutoLoot : public Feature
     {
 	public:
-		config::Field<config::Toggle<Hotkey>> f_AutoLoot;
-		config::Field<config::Toggle<Hotkey>> f_OpenChest;
+		config::Field<config::Toggle<Hotkey>> f_AutoPickup;
+		config::Field<config::Toggle<Hotkey>> f_AutoTreasure;
+		config::Field<config::Toggle<Hotkey>> f_UseCustomRange;
 
 		config::Field<int> f_DelayTime;
-		config::Field<bool> f_UseCustomRange;
 		config::Field<float> f_CustomRange;
+
+		config::Field<bool> f_Chest;
+		config::Field<bool> f_Leyline;
+		config::Field<bool> f_Investigate;
+		config::Field<bool> f_QuestInteract;
+		config::Field<bool> f_Others;
 
 		static AutoLoot& GetInstance();
 

--- a/cheat-library/src/user/cheat/world/AutoTreeFarm.cpp
+++ b/cheat-library/src/user/cheat/world/AutoTreeFarm.cpp
@@ -32,10 +32,10 @@ namespace cheat::feature
 			"Not recommended for main accounts or used with high values.");
 		
 		ConfigWidget("Enabled", m_Enabled, "Automatically attack trees in range.");
-		ConfigWidget("Attack Delay (ms)", m_AttackDelay, 1, 0, 1000, "Delay before next tree attack.");
-		ConfigWidget("Repeat Delay (ms)", m_RepeatDelay, 1, 500, 1000, "Delay before attacking same tree. <500 will not work.");
+		ConfigWidget("Attack Delay (ms)", m_AttackDelay, 1, 0, 1000, "Delay before attacking the next tree (in ms).");
+		ConfigWidget("Repeat Delay (ms)", m_RepeatDelay, 1, 500, 1000, "Delay before attacking the same tree (in ms).\nValues <500ms will not work.");
 
-		ConfigWidget("Attacks per Tree", m_AttackPerTree, 1, 0, 100, "Counts of attack for one tree.\n" \
+		ConfigWidget("Attacks per Tree", m_AttackPerTree, 1, 0, 100, "Count of attacks for one tree.\n" \
 			"Recommended to set to 10 or lower to avoid attacking empty trees.\n" \
 			"Set to 0 for unlimited attacks (even empty trees, extremely high risk).\n" \
 			"Note: Memorized trees' attacks are reset after game restart."

--- a/cheat-library/src/user/cheat/world/MobVacuum.cpp
+++ b/cheat-library/src/user/cheat/world/MobVacuum.cpp
@@ -30,7 +30,7 @@ namespace cheat::feature
 
     const FeatureGUIInfo& MobVacuum::GetGUIInfo() const
     {
-        static const FeatureGUIInfo info{ "Mob vacuum", "World", true };
+        static const FeatureGUIInfo info{ "Mob Vacuum", "World", true };
         return info;
     }
 
@@ -43,12 +43,12 @@ namespace cheat::feature
     	BeginGroupPanel("Monsters", ImVec2(-1, 0));
         {
             filtersChanged |= ConfigWidget(f_IncludeMonsters, "Include monsters in vacuum.");
-            filtersChanged |= ConfigWidget(f_MonsterCommon, "Common Enemies."); ImGui::SameLine();
-            filtersChanged |= ConfigWidget(f_MonsterElites, "Elite Enemies."); ImGui::SameLine();
-            filtersChanged |= ConfigWidget(f_MonsterBosses, "Boss Enemies.");
+            filtersChanged |= ConfigWidget(f_MonsterCommon, "Common enemies."); ImGui::SameLine();
+            filtersChanged |= ConfigWidget(f_MonsterElites, "Elite enemies."); ImGui::SameLine();
+            filtersChanged |= ConfigWidget(f_MonsterBosses, "World and Trounce boss enemies.");
         }
     	EndGroupPanel();
-
+        
     	BeginGroupPanel("Animals", ImVec2(-1, 0));
         {
             filtersChanged |= ConfigWidget(f_IncludeAnimals, "Include animals in vacuum.");


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6817524/166900900-033a4c3a-a2a7-49e6-b049-a90b8cf737cb.png)

- Redefined autoloot as Auto-pickup
- Auto-chest is now Auto-treasure
- Custom range can stand alone now and can be used with either, both, or neither AP or AT
- Filters for AT using `ItemType`

Should address #308.